### PR TITLE
Add bright color variants for text and background

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,8 @@ println!("Lets the user {color_red}colorize{color_reset} and {style_underline}st
 
 Just remember to reset the style, color or background when you want the default text setting
 
-  
+For an example of the expected result you can run:
+
+```
+cargo run --example all_codes
+```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ println!("Lets the user {color_red}colorize{color_reset} and {style_underline}st
 | color_magenta        |
 | color_cyan           |
 | color_white          |
+| color_bright_black   |
+| color_bright_red     |
+| color_bright_green   |
+| color_bright_yellow  |
+| color_bright_blue    |
+| color_bright_magenta |
+| color_bright_cyan    |
+| color_bright_white   |
 | color_reset          |
 
 
@@ -41,6 +49,14 @@ println!("Lets the user {color_red}colorize{color_reset} and {style_underline}st
 | bg_magenta                |
 | bg_cyan                   |
 | bg_white                  |
+| bg_bright_black           |
+| bg_bright_red             |
+| bg_bright_green           |
+| bg_bright_yellow          |
+| bg_bright_blue            |
+| bg_bright_magenta         |
+| bg_bright_cyan            |
+| bg_bright_white           |
 | bg_reset                  |
 
 Just remember to reset the style, color or background when you want the default text setting

--- a/examples/all_codes.rs
+++ b/examples/all_codes.rs
@@ -1,0 +1,45 @@
+use inline_colorization::*;
+
+fn main() {
+  println!("no_style");
+
+  // styles
+  println!("{style_bold}style_bold{style_reset}");
+  println!("{style_underline}style_underline{style_reset}");
+
+  // colors
+  println!("{bg_white}{color_black}color_black{color_reset}{bg_reset}");
+  println!("{color_red}color_red{color_reset}");
+  println!("{color_green}color_green{color_reset}");
+  println!("{color_yellow}color_yellow{color_reset}");
+  println!("{color_blue}color_blue{color_reset}");
+  println!("{color_magenta}color_magenta{color_reset}");
+  println!("{color_cyan}color_cyan{color_reset}");
+  println!("{color_white}color_white{color_reset}");
+  println!("{bg_white}{color_bright_black}color_bright_black{color_reset}{bg_reset}");
+  println!("{color_bright_red}color_bright_red{color_reset}");
+  println!("{color_bright_green}color_bright_green{color_reset}");
+  println!("{color_bright_yellow}color_bright_yellow{color_reset}");
+  println!("{color_bright_blue}color_bright_blue{color_reset}");
+  println!("{color_bright_magenta}color_bright_magenta{color_reset}");
+  println!("{color_bright_cyan}color_bright_cyan{color_reset}");
+  println!("{color_bright_white}color_bright_white{color_reset}");
+
+  // backgrounds
+  println!("{bg_black}bg_black{bg_reset}");
+  println!("{bg_red}bg_red{bg_reset}");
+  println!("{bg_green}bg_green{bg_reset}");
+  println!("{bg_yellow}bg_yellow{bg_reset}");
+  println!("{bg_blue}bg_blue{bg_reset}");
+  println!("{bg_magenta}bg_magenta{bg_reset}");
+  println!("{bg_cyan}bg_cyan{bg_reset}");
+  println!("{color_black}{bg_white}bg_white{bg_reset}{color_reset}");
+  println!("{bg_bright_black}bg_bright_black{bg_reset}");
+  println!("{bg_bright_red}bg_bright_red{bg_reset}");
+  println!("{bg_bright_green}bg_bright_green{bg_reset}");
+  println!("{bg_bright_yellow}bg_bright_yellow{bg_reset}");
+  println!("{bg_bright_blue}bg_bright_blue{bg_reset}");
+  println!("{bg_bright_magenta}bg_bright_magenta{bg_reset}");
+  println!("{bg_bright_cyan}bg_bright_cyan{bg_reset}");
+  println!("{color_black}{bg_bright_white}bg_bright_white{bg_reset}{color_reset}");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,22 @@ pub const color_cyan: &str = "\x1B[36m";
 #[allow(non_upper_case_globals)]
 pub const color_white: &str = "\x1B[37m";
 #[allow(non_upper_case_globals)]
+pub const color_bright_black: &str = "\x1B[90m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_red: &str = "\x1B[91m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_green: &str = "\x1B[92m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_yellow: &str = "\x1B[93m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_blue: &str = "\x1B[94m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_magenta: &str = "\x1B[95m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_cyan: &str = "\x1B[96m";
+#[allow(non_upper_case_globals)]
+pub const color_bright_white: &str = "\x1B[97m";
+#[allow(non_upper_case_globals)]
 pub const color_reset: &str = "\x1B[39m";
 
 #[allow(non_upper_case_globals)]
@@ -44,5 +60,21 @@ pub const bg_magenta: &str = "\x1B[45m";
 pub const bg_cyan: &str = "\x1B[46m";
 #[allow(non_upper_case_globals)]
 pub const bg_white: &str = "\x1B[47m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_black: &str = "\x1B[100m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_red: &str = "\x1B[101m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_green: &str = "\x1B[102m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_yellow: &str = "\x1B[103m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_blue: &str = "\x1B[104m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_magenta: &str = "\x1B[105m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_cyan: &str = "\x1B[106m";
+#[allow(non_upper_case_globals)]
+pub const bg_bright_white: &str = "\x1B[107m";
 #[allow(non_upper_case_globals)]
 pub const bg_reset: &str = "\x1B[49m";


### PR DESCRIPTION
Hi,
this adds bright color variants as per https://en.wikipedia.org/wiki/ANSI_escape_code#Colors to this crate.

Also added an example that when run gives this result for me:

![image](https://github.com/eliasjonsson023/inline_colorization/assets/864939/72fc79bb-2de4-4233-9f13-a5ede826b8ae)
